### PR TITLE
Correción de formato y propuesta de nuevo comando

### DIFF
--- a/templates/plantilla-practica-1/content/minitutorial.tex
+++ b/templates/plantilla-practica-1/content/minitutorial.tex
@@ -117,3 +117,30 @@ Pueden copiar y modificar el codigo siguiente:
     \end{table}
 \end{minipage}
 \newpage
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{TUTORIAL: Citación}
+
+Para citación extensa en formato APA, citas con más de 40 palabras, se sugiere el uso del siguiente comando personalizado:
+
+\begin{verbatim} 
+    \quote{cita}
+    Ejemplo:
+    \quote{\lipsum (Autor, Año)}
+\end{verbatim}
+
+\quote{\lipsum (Autor, Año)}
+
+Puedes realizarlo de forma manual modificando el código comentado
+
+%Cita extensa APA manual:
+
+%\begin{flushright}
+%    \begin{minipage}{0.96\linewidth}
+%        \vspace{5pt}
+%        {\small
+%            %Acá va la cita
+%        }
+%        \vspace{5pt}
+%    \end{minipage}
+%\end{flushright}

--- a/templates/plantilla-practica-1/style.cls
+++ b/templates/plantilla-practica-1/style.cls
@@ -141,7 +141,7 @@
 \titleformat{\section}[hang]
     {\bfseries}
     {\normalsize \thesection . \ }{0pt} 
-    {\normalsize}[\vspace{2ex}]
+    {\normalsize}[\vspace{2ex}\setcounter{figure}{0}\setcounter{table}{0}]
 \titleformat{\subsection}[hang]
     {\bfseries}
     {\normalsize \thesubsection. \ }{0pt}
@@ -172,7 +172,7 @@
     \centering
     \begin{measuredfigure}
         \ifx\relax#1\else\label{img:#1}\fi
-        \ifx\relax#2\else\caption{#2}\fi
+        \ifx\relax#2\else\caption{#2\vspace{2ex}}\fi
         \includegraphics[#3]{#4}%
     \end{measuredfigure}
   \end{figure}%
@@ -199,6 +199,21 @@
         \\ \textit{\scriptsize{#5}}
     \end{table}
 }
+
+% Insertar citación extensa (+40 palabras) en formato APA. Adaptación del siguiente código:
+% https://linuxgx.blogspot.com/2015/02/citas-textuales-largas-en-latex.html
+\newcommand{\quote}[1]{
+    \begin{flushright}
+        \begin{minipage}{0.96\linewidth}
+            \vspace{5pt}
+            {\small
+                #1
+            }
+            \vspace{5pt}
+        \end{minipage}
+    \end{flushright}
+}
+
 % Quitamos negrita indice de contenido
 % https://tex.stackexchange.com/questions/196598/remove-bold-from-table-of-contents
 \let\LaTeXStandardTableOfContents\tableofcontents


### PR DESCRIPTION
# Problema

Falta incluir "doble enter" entre el título de las imágenes y la figura. La numeración de las imágenes y tablas no se reinicia con cada nuevo capítulo. No hay una opción para facilitar crear citas extensas en formato APA.

## Solución

- Dentro de la definición del comando \fig se incluye "doble enter"
- Dentro de \titleformat para \section se incluye los comandos \setcounter{figure}{0} y \setcounter{table}{0} para reiniciar el contador de las imágenes y tablas para cada nueva sección.
- Se crea un nuevo comando \quote{cita} que permite dar un formato de citación extensa en APA al parámetro entregado.