### PR TITLE
fix: margin sizes

### DIFF
--- a/templates/plantilla-practica-1/style.cls
+++ b/templates/plantilla-practica-1/style.cls
@@ -3,7 +3,7 @@
 \LoadClass[12pt]{article}
 \RequirePackage{fullpage}
 \RequirePackage[spanish, es-noshorthands]{babel}
-\RequirePackage[letterpaper, left=3cm, top=3cm,right=2.5cm,bottom=2.5cm,margin=2cm]{geometry}
+\RequirePackage[letterpaper, left=3cm, top=3cm,right=2.5cm,bottom=2.5cm]{geometry}
 \selectlanguage{spanish}
 
 %----------------------------- TEXTO ---------------------------


### PR DESCRIPTION
# Los márgenes específicos del informe no se están aplicando

>> Los márgenes que se solicitan en el informe no se están aplicando debido a que se indica un parámetro demás, que es el margen de forma general, lo que provoca que los márgenes particulares no surtan efecto al compilar.

## Solución

>> Eliminar el parámetro sobrante del llamado al paquete de geometry