### PR TITLE
fix: add null indentation to appendix in order to undo the initial one

### DIFF
--- a/templates/plantilla-practica-2/content/anexos.tex
+++ b/templates/plantilla-practica-2/content/anexos.tex
@@ -1,3 +1,7 @@
+% Se explicita la indentacion de 0 in para que el anexo
+% no se vea perjudicado por el estilo de la biografia
+\leftskip 0in
+\parindent 0in
 \section{Anexos}
 % =============================================
 \subsection{Evaluación Personal}


### PR DESCRIPTION
# Problema

>> Habia una indentacion innecesaria en la seccion de anexo, lo que hacia que las lineas del parrafo estuvieran mal alineadas.
<img src="https://github.com/open-source-uc/latex-templates/assets/81534737/51a5f1a6-0712-49ab-a992-8f698009e87d" width="60" />

## Solución

>> Se añadio una indentacion nula en el apartado del anexo para invalidar la indentacion previa de la bibliografia.