### PR TITLE
fix: pdf rendering in main.tex

### DIFF
--- a/templates/plantilla-practica-1/main.tex
+++ b/templates/plantilla-practica-1/main.tex
@@ -19,12 +19,9 @@
 \renewcommand{\figurename}{Figura}
 \renewcommand*{\lstlistingname}{Código}
 
-%%%%%%%%%%%% Certificado de Entrega %%%%%%%%%%%%%%%
+%%%%%%%%%%%% Certificado de Entrega y Registro de Autorización de la Práctica %%%%%%%%%%%%%%%
 % Se sube un pdf:
-%\includepdf{content/certificado.pdf}
-
-%%%%%% Registro de Autorización de la Práctica %%%%%%%%%
-%\includepdf{content/registro.pdf}
+%\includepdf[pages=-]{content/certificado.pdf} % [pages=-] es para que se muestre todo el documento
 
 %%%%%%%%%%%%%%%%% PORTADA %%%%%%%%%%%%%%%%%
 \ThisCenterWallPaper{1}{content/portada.pdf}
@@ -34,13 +31,10 @@
         {\today} % Insertar fecha
 
 %%%%% Formulario de Evaluación de la U %%%%%%%%
-%\includepdf{content/formulario.pdf}
-
-%%%%% Formulario de Evaluación de la U %%%%%%%%
-%\includepdf{content/formulario.pdf}
+%\includepdf[pages=-]{content/formularioUniversidad.pdf}
 
 %%%%%%%% Formulario de Evaluación de la Empresa %%%%%%%
-%\includepdf{content/formulario.pdf}
+%\includepdf[pages=-]{content/formularioEmpresa.pdf}
 
 %%%%%%%%%%%% Numeración paginas %%%%%%%%%%%
 \pagenumbering{arabic}


### PR DESCRIPTION
# Problema

>> Al momento de insertar archivos en PDF en `main.tex`, únicamente se visualizaba la primera página de este, dejándolo incompleto en la compilación, además, el certificado de entrega y la autorización de la práctica estaban en archivos separados, cuando la DIPRE genera los dos documentos en uno solo.

## Solución

>> Lista con soluciones implementadas.

- agregar `[pages=-]` a cada `\includepdf` en `main.tex`
- Juntar certificado de entrega y autorización de práctica en una sola línea