### PR TITLE
fix: Se arregla el interlineado, la sangria y los indices

### DIFF
--- a/templates/informes-uc/style.cls
+++ b/templates/informes-uc/style.cls
@@ -66,7 +66,8 @@
 \RequirePackage{pdfpages}                   % insertar pdfs ya creados
 \RequirePackage{titlesec}                   % Define formatos para \section y +
 %\RequirePackage[backend=biber,style=apa]{biblatex}
-\RequirePackage{natbib}                     % Referencias bibliograficas mas comodas
+%\RequirePackage{natbib}                     % Referencias bibliograficas mas comodas
+\RequirePackage[natbibapa]{apacite}         % Referencias bibliograficas APA
 
 % \RequirePackage[none]{hyphenat}           %  Evita que las palabras se corten(Puede verse mal)
 \usetikzlibrary{mindmap}                    %,trees,intersections,arrows,automata

--- a/templates/plantilla-practica-1/style.cls
+++ b/templates/plantilla-practica-1/style.cls
@@ -70,7 +70,8 @@
 \RequirePackage{pdfpages}                   % insertar pdfs ya creados
 \RequirePackage{titlesec}                   % Define formatos para \section y +
 %\RequirePackage[backend=biber,style=apa]{biblatex}
-\RequirePackage{natbib}                     % Referencias bibliograficas mas comodas
+% \RequirePackage{natbib}                     % Referencias bibliograficas mas comodas
+\RequirePackage[natbibapa]{apacite}         % Referencias bibliograficas APA
 
 % \RequirePackage[none]{hyphenat}           %  Evita que las palabras se corten(Puede verse mal)
 \usetikzlibrary{mindmap}                    %,trees,intersections,arrows,automata

--- a/templates/plantilla-practica-2/content/anexos.tex
+++ b/templates/plantilla-practica-2/content/anexos.tex
@@ -1,7 +1,7 @@
 % Se explicita la indentacion de 0 in para que el anexo
 % no se vea perjudicado por el estilo de la biografia
 \leftskip 0in
-\parindent 0in
+\parindent 0.49cm % Sangria segun el manual la tenemos que volver a establecer
 \section{Anexos}
 % =============================================
 \subsection{Evaluación Personal}

--- a/templates/plantilla-practica-2/main.tex
+++ b/templates/plantilla-practica-2/main.tex
@@ -6,16 +6,7 @@
 \documentclass{style}
 
 \begin{document}
-%%%%%%%%%%%%%%%%% RENOMBRE %%%%%%%%%%%%%%%%%
 \graphicspath{ {./img/} }
-\renewcommand\cftsecfont{\normalsize}
-\renewcommand\cftsecpagefont{\normalsize}
-\renewcommand{\contentsname}{\normalsize Tabla de Contenido}
-\renewcommand{\listfigurename}{\normalsize Índice de Ilustraciones}
-\renewcommand{\listtablename}{\normalsize Índice de Tablas}
-\renewcommand{\tablename}{Tabla}
-\renewcommand{\figurename}{Figura}
-\renewcommand*{\lstlistingname}{Código}
 
 %%%%%%%%%%%%%%%%% PORTADA %%%%%%%%%%%%%%%%%
 \ThisCenterWallPaper{1}{content/portada.pdf}
@@ -34,8 +25,6 @@
 \tableofcontents \newpage
 \listoftables \newpage
 \listoffigures \newpage
-%%%%%%%%%%%%%%%%% ESPACIADO %%%%%%%%%%%%%%%%%
-\setstretch{1.15}
 %%%%%%%%%%%%%%%%% CONTENIDO %%%%%%%%%%%%%%%%%
 
 \input{content/contenido}

--- a/templates/plantilla-practica-2/style.cls
+++ b/templates/plantilla-practica-2/style.cls
@@ -2,43 +2,53 @@
 \NeedsTeXFormat{LaTeX2e}                    % Requiere formato LaTeX2e
 \ProvidesClass{style}                       % Define la clase del documento
 \LoadClass[12pt]{article}                   % Carga la clase de artículo con tamaño de fuente de 12pt
-\setlength{\parindent}{0.49cm}              % Establece la sangría de los párrafos
 \RequirePackage{fullpage}                   % Utiliza la página completa
 \RequirePackage[spanish, es-noshorthands]{babel} % Configuración de idioma español
-\RequirePackage[letterpaper, left=4cm, top=4cm,right=2.5cm,bottom=2.5cm]{geometry} % Configuración de márgenes
 \selectlanguage{spanish}                    % Selecciona el idioma español
+\addto\captionsspanish{                     % Renombramos los indices
+  \renewcommand{\contentsname}{Tabla de Contenido}
+  \renewcommand{\listfigurename}{Índice de Ilustraciones}
+  \renewcommand{\listtablename}{Índice de Tablas}
+  \renewcommand{\tablename}{Tabla}
+  \renewcommand{\figurename}{Figura}
+  \renewcommand*{\lstlistingname}{Código}
+}
+\RequirePackage[letterpaper, left=4cm, top=4cm,right=2.5cm,bottom=2.5cm]{geometry} % Configuración de márgenes
 \title{Informe de práctica II}              % Título del documento
 
 % ====== Estilo de Texto ======
-\RequirePackage{mathptmx}                       % Utiliza la fuente Times New Roman
-\RequirePackage[LY1]{fontenc}                   % Codificación de fuente
+\RequirePackage{mathptmx}                   % Utiliza la fuente Times New Roman
+\RequirePackage[LY1]{fontenc}               % Codificación de fuente
 \RequirePackage{tocloft}                    % Para indices
 \RequirePackage{parskip}                    % Configura los espacios entre párrafos y sangrías
 \RequirePackage{xspace}                     % Agrega espacios automáticamente después de comandos
 \RequirePackage{microtype}                  % Mejora el espaciado entre letras para una apariencia más agradable
 \RequirePackage{setspace}                   % Permite controlar el interlineado
 \setstretch{1.5}                            % Establece el interlineado
+\setlength{\parindent}{0.49cm}              % Establece la sangría de los párrafos
 \RequirePackage{ulem}                       % Permite tachar el texto
 \RequirePackage{textcomp}                   % Añade símbolos especiales como el símbolo de copyright
-\RequirePackage{mfirstuc}                   % Agrega comandos para capitalizar
+\RequirePackage{mfirstuc}                    % Agrega comandos para capitalizar
 \RequirePackage{dirtytalk}                  % Facilita la adición de comillas
 \RequirePackage{soul}                       % Permite resaltar y decorar texto
 \RequirePackage{bold-extra}                 % Permite utilizar negritas en texto monoespaciado
 \RequirePackage{lscape}                     % Permite orientación horizontal de las páginas
 \RequirePackage{titlesec}                   % Permite personalizar los estilos de sección
+\renewcommand\cftsecfont{\normalsize}       % Estilo indice
+\renewcommand\cftsecpagefont{\normalsize}   % Estilo indice
 
 % ====== Ecuaciones ======
 \RequirePackage{amsmath,amsthm,mathtools,amssymb,amsfonts,mathrsfs,latexsym,stmaryrd}
 
 % ====== Imágenes ======
 \RequirePackage{threeparttable}             % Alinea imágenes con las leyendas
-\RequirePackage{float}                      % Mejora la ubicación de las figuras
+\RequirePackage{float}                       % Mejora la ubicación de las figuras
 \RequirePackage{graphicx}                   % Mejora la inclusión de imágenes
-\RequirePackage{epsfig}                     % Soporte para imágenes EPS
+\RequirePackage{epsfig}                      % Soporte para imágenes EPS
 \RequirePackage{caption}                    % Personalización de leyendas de figuras
 \RequirePackage{subcaption}                 % Leyendas en subfiguras
 \RequirePackage{tikz}                       % Herramienta para crear gráficos
-\RequirePackage{wrapfig}                    % Permite envolver texto alrededor de figuras
+\RequirePackage{wrapfig}                     % Permite envolver texto alrededor de figuras
 
 % ====== Tablas ======
 \RequirePackage{tabularx}                   % Mejora la creación de tablas
@@ -68,6 +78,7 @@
 \RequirePackage{placeins}                   % Controla la ubicación de las figuras
 \RequirePackage[most]{tcolorbox}            % Creación de cajas de colores
 \RequirePackage{bm}                         % Mejora el manejo de símbolos en negritas en matemáticas
+\RequirePackage[natbibapa]{apacite}
 
 % ====== Opcionales ======
 %\RequirePackage{dirtree}                    % Para generar árboles de directorios


### PR DESCRIPTION
# Problema

Se habían roto el interlineado, la sangría y el renombre de índices

- Aproveche de agregar un paquete que genera mejores citas si se usa un .bib