### PR TITLE
Fix formato plantilla práctica 2

### DIFF
--- a/templates/plantilla-practica-2/content/abstract.tex
+++ b/templates/plantilla-practica-2/content/abstract.tex
@@ -8,7 +8,7 @@
 
 \selectlanguage{British}
 
-{\Large\textbf{Abstract}}\par
+\noindent{\Large\textbf{Abstract}\par\vspace{1ex}}
 
 To fill out the executive summary in English (200-400 words), follow these steps. Start with a brief overview of the context. State the company's goals or objectives for the project's conclusion. List the tasks carried out during the project. Explain the methodologies used. Highlight the main outcomes. Conclude with general findings or conclusions from the technical report.
 

--- a/templates/plantilla-practica-2/main.tex
+++ b/templates/plantilla-practica-2/main.tex
@@ -19,14 +19,12 @@
 %%%%%%%%%%%%%%%%% ABSTRACT %%%%%%%%%%%%%%%%%
 \input{content/abstract}
 
-%%%%%%%%%%%% Numeración paginas %%%%%%%%%%%
-\pagenumbering{arabic}
 %%%%%%%%%%%%%%%%% INDICES %%%%%%%%%%%%%%%%%
 \tableofcontents \newpage
 \listoftables \newpage
 \listoffigures \newpage
-%%%%%%%%%%%%%%%%% CONTENIDO %%%%%%%%%%%%%%%%%
 
+%%%%%%%%%%%%%%%%% CONTENIDO %%%%%%%%%%%%%%%%%
 \input{content/contenido}
 
 %%%%%%%%%%%%%%%%% BIBLIOGRAFIA %%%%%%%%%%%%%%%%%

--- a/templates/plantilla-practica-2/style.cls
+++ b/templates/plantilla-practica-2/style.cls
@@ -16,6 +16,20 @@
 \RequirePackage[letterpaper, left=2.5cm, top=2.5cm, right=2.5cm, bottom=2.5cm]{geometry} % Configuración de márgenes
 \title{Informe de práctica II}              % Título del documento
 
+% Configuración de numeración de páginas
+\pagenumbering{arabic}
+\usepackage{fancyhdr}                       
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[R]{\thepage}
+\renewcommand\headrulewidth{0pt}
+
+\fancypagestyle{plain}{%
+    \fancyhf{}%
+    \fancyhead[R]{\thepage}%
+    \renewcommand{\headrulewidth}{0pt}%
+}
+
 % ====== Estilo de Texto ======
 \RequirePackage{mathptmx}                   % Utiliza la fuente Times New Roman
 \RequirePackage[LY1]{fontenc}               % Codificación de fuente
@@ -222,8 +236,6 @@
 \endgroup%
 }%
 
-% configuramos numeros de pagina desactivados hasta que se quiera
-\pagenumbering{gobble}
 %%%%%%%%%%%%%%%%%%%%%%% CAPTION %%%%%%%%%%%%%%%%%%%%%%%
 \captionsetup[table]{format=plain, font=small, justification=raggedright, skip=1pt, singlelinecheck=false}
 

--- a/templates/plantilla-practica-2/style.cls
+++ b/templates/plantilla-practica-2/style.cls
@@ -169,11 +169,11 @@
 % \portada{Insertar nombre aca}{Insertar correo acá}{Insertar empresa acá}{Insertar fecha acá}
 \newcommand{\portada}[5]{
     \begin{tikzpicture}[remember picture, overlay]
-        \node[text=black, right] at (5,-13.7) {#1};
-        \node[text=black, right] at (5,-14.8) {#2};
-        \node[text=black, right] at (5,-15.9) {#3};
-        \node[text=black, right] at (5,-17.1) {#4};
-        \node[text=black, right] at (5,-18.2) {#5};
+        \node[text=black, right] at (3.5,-15.15) {#1};
+        \node[text=black, right] at (3.5,-16.3) {#2};
+        \node[text=black, right] at (3.5,-17.45) {#3};
+        \node[text=black, right] at (3.5,-18.6) {#4};
+        \node[text=black, right] at (3.5,-19.7) {#5};
     \end{tikzpicture}
     \newpage
 }


### PR DESCRIPTION
# Problema

>> La numeración de las páginas del informe no cumple con lo solicitado actualmente. 
>> El subtítulo del Abstract tiene una sangría adicional que no debiese estar, y falta de salto de línea. 
>> Las posiciones de los nodos de texto en la portada no calzan con los espacios de la portada

## Solución

>> Lista con soluciones implementadas.

- Se usa el paquete fancyhdr para configurar la numeración de páginas. Se eliminan los reinicios de índices para que únicamente comiencen desde la portada.
- Se ajusta la línea de texto del abstract para que no tenga sangría y además agregue un salto de línea adicional respecto del texto a continuación.
- Se ajustan las posiciones de los nodos de texto en la definición de la portada.