### PR TITLE
fix: update header height within top margin

### DIFF
--- a/templates/plantilla-practica-2/style.cls
+++ b/templates/plantilla-practica-2/style.cls
@@ -13,7 +13,7 @@
   \renewcommand{\figurename}{Figura}
   \renewcommand*{\lstlistingname}{Código}
 }
-\RequirePackage[letterpaper, left=2.5cm, top=2.5cm, right=2.5cm, bottom=2.5cm]{geometry} % Configuración de márgenes
+\RequirePackage[letterpaper, left=2.5cm, top=2.5cm, right=2.5cm, bottom=2.5cm, headheight=14.5pt]{geometry} % Configuración de márgenes
 \title{Informe de práctica II}              % Título del documento
 
 % Configuración de numeración de páginas


### PR DESCRIPTION
# Problema

>> Redactando mi informe de práctica, me di cuenta que al tener una página que comience con un párrafo, el texto se sobreponía con la numeración.

## Solución

>> Se definió el valor explícito del `headheight=14.5pt` para que este sea considerado dentro del margen superior y no reste tampoco espacio al texto, incrementando artificialmente el margen.

* Validar revisando que el margen superior no se haya incrementado con respecto a los valores indicados en el manual de práctica.
