### PR TITLE
Plantilla Informes AST FIZ

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "templates/plantillas-thesis"]
 	path = templates/plantillas-thesis
 	url = https://github.com/open-source-uc/latex-template-msc
+[submodule "templates/informes-ast-fiz-uc"]
+	path = templates/informes-ast-fiz-uc
+	url = https://github.com/jj-sm/TeX-AST.git


### PR DESCRIPTION
# Plantilla TeX para informes de AST y FIZ

Plantilla basada de la base de TeX de [AASTeXv7](https://journals.aas.org/aastexguide/) modificada para adaptarla al uso de presentar informes y laboratorios.

![](https://github.com/user-attachments/assets/49c6ab83-9f36-4e0e-a5d1-7876a4e16187)


> First PR here ❤️ !