### PR TITLE
Remove \renewcommand{\exists}{\;\exists\;}

### DIFF
--- a/templates/informes-uc/style.cls
+++ b/templates/informes-uc/style.cls
@@ -106,7 +106,6 @@
 \renewcommand{\]}{\right]}
 \newcommand{\foral}{\;\forall\;}
 \newcommand{\exist}{\;\exists\;}
-\renewcommand{\exists}{\;\exists\; }
 \newcommand{\contr}{\rightarrow\leftarrow}
 \renewcommand{\phi}{\varphi}
 %\newcommand{\norm}[1]{\left\lVert #1 \right\rVert}

--- a/templates/plantilla-iPres/style.cls
+++ b/templates/plantilla-iPres/style.cls
@@ -97,7 +97,6 @@
 \renewcommand{\]}{\right]}
 \newcommand{\foral}{\;\forall\;}
 \newcommand{\exist}{\;\exists\;}
-\renewcommand{\exists}{\;\exists\; }
 \newcommand{\contr}{\rightarrow\leftarrow}
 \renewcommand{\phi}{\varphi}
 

--- a/templates/plantilla-practica-1/style.cls
+++ b/templates/plantilla-practica-1/style.cls
@@ -110,7 +110,6 @@
 \renewcommand{\]}{\right]}
 \newcommand{\foral}{\;\forall\;}
 \newcommand{\exist}{\;\exists\;}
-\renewcommand{\exists}{\;\exists\; }
 \newcommand{\contr}{\rightarrow\leftarrow}
 \renewcommand{\phi}{\varphi}
 %\newcommand{\norm}[1]{\left\lVert #1 \right\rVert}

--- a/templates/plantilla-practica-2/style.cls
+++ b/templates/plantilla-practica-2/style.cls
@@ -120,7 +120,6 @@
 \renewcommand{\]}{\right]}
 \newcommand{\foral}{\;\forall\;}
 \newcommand{\exist}{\;\exists\;}
-\renewcommand{\exists}{\;\exists\; }
 \newcommand{\contr}{\rightarrow\leftarrow}
 \renewcommand{\phi}{\varphi}
 

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -110,7 +110,6 @@
 \renewcommand{\]}{\right]}
 \newcommand{\foral}{\;\forall\;}
 \newcommand{\exist}{\;\exists\;}
-\renewcommand{\exists}{\;\exists\; }
 \newcommand{\contr}{\rightarrow\leftarrow}
 \renewcommand{\phi}{\varphi}
 


### PR DESCRIPTION
Removi la redefinicion del comando \exists a \;\exists\; en los archivos style.cls ya que genera una llamada recursiva infinita y no permite compilar el archivo.


Explicacion de copilot:
This pull request removes redundant redefinitions of the `\exists` command across multiple LaTeX style files. These changes simplify the codebase and ensure consistency by relying on the original definition of `\exists`.

Redundant command removal:

* [`templates/informes-uc/style.cls`](diffhunk://#diff-f6a8b636df9d13e12a07db4fbe9caa161fccb75e88490c6db6b929bfd5dde3cbL109): Removed the redundant redefinition of `\exists` to simplify the file.
* [`templates/plantilla-iPres/style.cls`](diffhunk://#diff-6e7b027dc9c6a04ee331a726d24f889782473aa7bdb90e550b0c9639d553c67aL100): Removed the redundant redefinition of `\exists` for consistency.
* [`templates/plantilla-practica-1/style.cls`](diffhunk://#diff-3be293c04286ad6591b0fbe1f5d43d442c954fa334ee3bd7ec0064c51f1b10b0L113): Simplified the file by removing the unnecessary redefinition of `\exists`.
* [`templates/plantilla-practica-2/style.cls`](diffhunk://#diff-aab4d64a1cb3c34bb3109cf6cb640e97aea20c5867461200540c78706bfd778eL123): Eliminated the redundant redefinition of `\exists` to streamline the code.
* [`templates/plantilla-trabajo-de-titulo/style.cls`](diffhunk://#diff-f15b00198b30a25f04b40942ef46f413b5a3689bd337288743ebbb841ab5962eL113): Removed the redundant redefinition of `\exists` for better maintainability.
