### PR TITLE
fix: se arregla la numeración, el interlineado y las citas de la plantilla de trabajo de título

### DIFF
--- a/templates/plantilla-trabajo-de-titulo/content/portada-1.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/portada-1.tex
@@ -1,4 +1,6 @@
 
+% The counter keeps advancing even though the number is not printed here
+\thispagestyle{empty}
 \begin{tikzpicture}[remember picture, overlay]
 \draw[thin] ([xshift=6.85cm, yshift=-2.5cm]current page.north west)|-([xshift=6.85cm, yshift=2.5cm]current page.south west);
 \end{tikzpicture}

--- a/templates/plantilla-trabajo-de-titulo/content/portada-2.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/portada-2.tex
@@ -1,4 +1,6 @@
 
+% The counter keeps advancing even though the number is not printed here
+\thispagestyle{empty}
 \begin{tikzpicture}[remember picture, overlay]
 \draw[thin] ([xshift=6.85cm, yshift=-2.5cm]current page.north west)|-([xshift=6.85cm, yshift=2.5cm]current page.south west);
 \end{tikzpicture}

--- a/templates/plantilla-trabajo-de-titulo/main.tex
+++ b/templates/plantilla-trabajo-de-titulo/main.tex
@@ -69,10 +69,6 @@
 %%%%%%%%%%%%%%%%% ABSTRACT %%%%%%%%%%%%%%%%%
 \input{content/abstract}
 
-\pagenumbering{arabic}
-
-
-
 %%%%%%%%%%%%%%%%% CONTENIDO %%%%%%%%%%%%%%%%%
 
 \input{content/contenido}
@@ -81,8 +77,8 @@
 \newpage
 % Hay 2 formas de agregar bibliografia:
 % 1. Agregar una bibliografia en un archivo .bib (Es super automatico)
-% \bibliographystyle{apacite}
-% \bibliography{mybib.bib} % Requiere crear un archivo .bib
+%    En el preambulo: \usepackage[style=apa]{biblatex} y \addbibresource{mybib.bib}
+% \printbibliography[title={REFERENCIAS BIBLIOGRÁFICAS}] % Requiere compilar con biber
 
 % 2. Agregar una bibliografia en un archivo .tex
 % (Es manual, pero comodo para los que no conoce el bibtex)

--- a/templates/plantilla-trabajo-de-titulo/main.tex
+++ b/templates/plantilla-trabajo-de-titulo/main.tex
@@ -20,9 +20,8 @@
 
 
 % Set page number at the top right corner
-\ihead{} % Clear left header
-\chead{} % Clear center header
-\ohead{\thepage} % Set page number at right header
+\clearpairofpagestyles
+\ohead*{\thepage}
 
 
 \renewcommand{\cfttoctitlefont}{\hfill\Large}

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -2,7 +2,6 @@
 \NeedsTeXFormat{LaTeX2e}                    % Requiere formato LaTeX2e
 \ProvidesClass{style}                       % Define la clase del documento
 \LoadClass[12pt]{article}                   % Carga la clase de artículo con tamaño de fuente de 12pt
-\RequirePackage{fullpage}                   % Utiliza la página completa
 \RequirePackage[spanish, es-noshorthands]{babel} % Configuración de idioma español
 \selectlanguage{spanish}                    % Selecciona el idioma español
 \addto\captionsspanish{                     % Renombramos los indices
@@ -24,7 +23,7 @@
 \RequirePackage{xspace}                     % Agrega espacios automáticamente después de comandos
 \RequirePackage{microtype}                  % Mejora el espaciado entre letras para una apariencia más agradable
 \RequirePackage{setspace}                   % Permite controlar el interlineado
-\setstretch{1.2}                            % Establece el interlineado
+\setstretch{1.0}                            % Establece el interlineado
 \setlength{\parindent}{1.27cm}              % Establece la sangría de los párrafos
 \RequirePackage{ulem}                       % Permite tachar el texto
 \RequirePackage{textcomp}                   % Añade símbolos especiales como el símbolo de copyright
@@ -79,7 +78,7 @@
 \RequirePackage{placeins}                   % Controla la ubicación de las figuras
 \RequirePackage[most]{tcolorbox}            % Creación de cajas de colores
 \RequirePackage{bm}                         % Mejora el manejo de símbolos en negritas en matemáticas
-\RequirePackage[natbibapa]{apacite}
+\RequirePackage{natbib}                     % Citas \citep y \citet; no se usa apacite porque quedó en APA 6
 \RequirePackage{adjustbox}
 
 % ====== Opcionales ======
@@ -214,8 +213,8 @@
 \endgroup%
 }%
 
-% configuramos numeros de pagina desactivados hasta que se quiera
-\pagenumbering{gobble}
+% La guía exige numerar a partir de la portada
+\pagenumbering{arabic}
 %%%%%%%%%%%%%%%%%%%%%%% CAPTION %%%%%%%%%%%%%%%%%%%%%%%
 \captionsetup[table]{format=plain, font=small, justification=centering, skip=1pt, singlelinecheck=false}
 


### PR DESCRIPTION
# Problema

En base a lo detallado en Siding respecto al informe:

> - En su condición final, debe cumplir con los siguientes criterios mínimos de formato: 
>   - Extensión mínima de 15 páginas y una extensión máxima de 25  en **espaciamiento simple**, de acuerdo al formato establecido por la Dirección de Pregrado.
>   ...
>   - Numeración de páginas: debe utilizar números cardinales, ubicados en equina superior derecha de cada página. **Se enumera a partir de la portada.**
>   ...
>   - Las citas bibliográficas deben seguir el formato de la **última edición** de las normas APA.


Veo 3 discrepancias en el template:

- **Numeración**: la guía pide numerar *a partir de la portada*. `style.cls` fija `\pagenumbering{gobble}` y `main.tex` activa la numeración después del abstract, así que portada, dedicatoria, índices, resumen y abstract salen sin número y el cuerpo reinicia en 1.
- **Interlineado**: la guía pide espaciamiento simple y la plantilla trae `\setstretch{1.2}` (17,3 pt en vez de 14,5 pt).
- **Citas**: la guía pide la última edición de APA (7ª) y se carga `apacite`, que implementa la 6ª.

## Solución

- Se activa `\pagenumbering{arabic}` desde la primera página en `style.cls` y se elimina el reinicio posterior al abstract en `main.tex`.
  - Me pareció más limpio ocultar la numeración en las portadas, pero partiendo en abstract desde la página 3.
- Se limpian ambos estilos con `\clearpairofpagestyles` y se usa la versión estrellada `\ohead*{\thepage}`, que configura `scrheadings` y `plain` a la vez, para que los índices también numeren arriba a la derecha.
- `\setstretch{1.2}` pasa a `\setstretch{1.0}`.
- Se reemplaza `apacite` por `natbib` para las citas en el texto (`\citep` / `\citet`, cuyo formato no cambió entre ediciones) para usar bibliografía automática en APA 7.
- Se elimina `\RequirePackage{fullpage}`, que quedaba anulado por el `geometry` cargado a continuación con los márgenes correctos de 2,5 cm.

Validación: compilada con `latexmk -xelatex` antes y después, midiendo sobre el PDF resultante.

| Criterio | Antes | Después |
|---|---|---|
| Páginas numeradas arriba a la derecha | 8 de 16 | 16 de 16, correlativas desde la portada |
| Interlineado del cuerpo | 17,3 pt | 14,5 pt (simple a 12 pt) |
| Márgenes | 2,5 cm | 2,5 cm |
| Sangría de primera línea | 1,28 cm | 1,28 cm |

Compila sin errores y con exactamente los mismos warnings que `master`.
