### PR TITLE
fix: se completan las reglas de formato pendientes en la plantilla de trabajo de título

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Consulta [contributing.md](contributing.md) para más detalles sobre el proceso.
 - [diegocostares](https://github.com/diegocostares)
 - [EnzoMorata](https://github.com/EnzoMorata)
 - [FarDust](https://github.com/FarDust)
+- [fguinez](https://github.com/fguinez)
 - [Ivanvlam](https://github.com/Ivanvlam)
 - [lnatero](https://github.com/lnatero)
 - [lopezjurip](https://github.com/lopezjurip)

--- a/templates/plantilla-trabajo-de-titulo/content/abstract.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/abstract.tex
@@ -5,7 +5,7 @@
 \begin{center}
     \textbf{ABSTRACT}
 \end{center}
-\addcontentsline{toc}{section}{ABSTRACT}
+\tocsection{ABSTRACT}
 \vspace{1cm}
 (Abstract en inglés que no debe exceder una página.) (Normal)
 \selectlanguage{Spanish}

--- a/templates/plantilla-trabajo-de-titulo/content/agradecimientos.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/agradecimientos.tex
@@ -2,7 +2,7 @@
 \begin{center}
     \textbf{AGRADECIMIENTOS}
 \end{center}
-\addcontentsline{toc}{section}{AGRADECIMIENTOS}
+\tocsection{AGRADECIMIENTOS}
 \vspace{1cm}
 (Nota redactada sobriamente en la cual se agradece a quienes han colaborado en la elaboración del trabajo.) \textit{(Normal)}
 

--- a/templates/plantilla-trabajo-de-titulo/content/anexos.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/anexos.tex
@@ -2,8 +2,12 @@
 \begin{center}
 \vspace*{\fill}
     
-\textbf{ANEXOS}
-\addcontentsline{toc}{section}{ANEXOS}
+% La guia titula la portadilla "A N E X O S". El espaciado lo pone
+% \spacedletters (soul) y no espacios literales, para que la palabra siga
+% siendo una sola. En el indice va sin espaciar: la palabra separada se lee
+% mal en una lista de titulos.
+\textbf{\spacedletters{ANEXOS}}
+\tocsection{ANEXOS}
 \vspace*{\fill}
 \end{center}
 \newpage

--- a/templates/plantilla-trabajo-de-titulo/content/anexos.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/anexos.tex
@@ -2,10 +2,7 @@
 \begin{center}
 \vspace*{\fill}
     
-% La guia titula la portadilla "A N E X O S". El espaciado lo pone
-% \spacedletters (soul) y no espacios literales, para que la palabra siga
-% siendo una sola. En el indice va sin espaciar: la palabra separada se lee
-% mal en una lista de titulos.
+% La guía titula la portadilla "A N E X O S"; en el índice va sin espaciar
 \textbf{\spacedletters{ANEXOS}}
 \tocsection{ANEXOS}
 \vspace*{\fill}

--- a/templates/plantilla-trabajo-de-titulo/content/bibliografia.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/bibliografia.tex
@@ -1,7 +1,5 @@
 \indent
-% La guia lista la bibliografia sin numeral: no entra en la secuencia de
-% capitulos (I., II., ...). Va como seccion sin numerar y se agrega al indice a
-% mano, igual que RESUMEN, ABSTRACT o GLOSARIO.
+% La guía lista la bibliografía sin numeral de capítulo, igual que RESUMEN, ABSTRACT o GLOSARIO
 \section*{BIBLIOGRAFIA}
 \tocsection{BIBLIOGRAFIA}
 \leftskip 0.3in

--- a/templates/plantilla-trabajo-de-titulo/content/bibliografia.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/bibliografia.tex
@@ -1,5 +1,9 @@
 \indent
-\section{REFERENCIAS BIBLIOGRÁFICAS}
+% La guia lista la bibliografia sin numeral: no entra en la secuencia de
+% capitulos (I., II., ...). Va como seccion sin numerar y se agrega al indice a
+% mano, igual que RESUMEN, ABSTRACT o GLOSARIO.
+\section*{BIBLIOGRAFIA}
+\tocsection{BIBLIOGRAFIA}
 \leftskip 0.3in
 \parindent -0.3in
 

--- a/templates/plantilla-trabajo-de-titulo/content/contenido.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/contenido.tex
@@ -6,8 +6,6 @@ IMPORTANTE: estas secciones son a modo de ejemplo, no lo tomes como que debe ser
 
 \subsection{Descripción de la empresa}
 
-% Ejemplo de tabla: el rotulo "Tabla 1.1" lo arma \thetable (capitulo y
-% correlativo) y la entrada del indice de tablas sale del \caption.
 \begin{table}[H]
     \centering
     \caption{Comparación de técnicas basadas en modelos}
@@ -22,8 +20,7 @@ IMPORTANTE: estas secciones son a modo de ejemplo, no lo tomes como que debe ser
     \end{tabular}
 \end{table}
 
-En la Tabla \ref{tab:ejemplo} se muestra un ejemplo de tabla con su rótulo y su
-entrada en el índice de tablas.
+En la Tabla \ref{tab:ejemplo} se muestra un ejemplo de tabla con su rótulo y su entrada en el índice de tablas.
 
 \subsection{Rol del estudiante}
 

--- a/templates/plantilla-trabajo-de-titulo/content/contenido.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/contenido.tex
@@ -6,6 +6,25 @@ IMPORTANTE: estas secciones son a modo de ejemplo, no lo tomes como que debe ser
 
 \subsection{Descripción de la empresa}
 
+% Ejemplo de tabla: el rotulo "Tabla 1.1" lo arma \thetable (capitulo y
+% correlativo) y la entrada del indice de tablas sale del \caption.
+\begin{table}[H]
+    \centering
+    \caption{Comparación de técnicas basadas en modelos}
+    \label{tab:ejemplo}
+    \begin{tabular}{lcc}
+        \hline
+        Concepto              & Modelación analítica & Modelación por simulación \\
+        \hline
+        Tiempo de aprendizaje & 4                    & 1                         \\
+        Costo de construcción & 1                    & 5                         \\
+        \hline
+    \end{tabular}
+\end{table}
+
+En la Tabla \ref{tab:ejemplo} se muestra un ejemplo de tabla con su rótulo y su
+entrada en el índice de tablas.
+
 \subsection{Rol del estudiante}
 
 \subsection{Objetivos del proyecto}

--- a/templates/plantilla-trabajo-de-titulo/content/dedicatoria.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/dedicatoria.tex
@@ -1,7 +1,7 @@
 % Dedication Page
 \vspace*{0.7\textheight}
 \hfill
-\addcontentsline{toc}{section}{DEDICATORIA}
+\tocsection{DEDICATORIA}
 \begin{minipage}{0.4\textwidth}
     (A mis Padres, hermanos y amigos,\\
     que me apoyaron mucho.)\\

--- a/templates/plantilla-trabajo-de-titulo/content/glosario.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/glosario.tex
@@ -4,7 +4,7 @@
 \begin{center}
     \textbf{GLOSARIO}
 \end{center}
-\addcontentsline{toc}{section}{GLOSARIO} 
+\tocsection{GLOSARIO} 
 \vspace{1cm}
 
 (opcional)

--- a/templates/plantilla-trabajo-de-titulo/content/portada-1.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/portada-1.tex
@@ -1,46 +1,47 @@
 
-% The counter keeps advancing even though the number is not printed here
+% La numeración sigue contando desde la portada, pero no se imprime aquí
 \thispagestyle{empty}
-\begin{tikzpicture}[remember picture, overlay]
-\draw[thin] ([xshift=6.85cm, yshift=-2.5cm]current page.north west)|-([xshift=6.85cm, yshift=2.5cm]current page.south west);
-\end{tikzpicture}
-\begin{minipage}{0.2\textwidth}
-    \includegraphics[width=2.3cm]{content/logo.png}
-\end{minipage}%
-\hspace{0cm} % Adjust horizontal spacing
-\begin{minipage}{0.75\textwidth}
-    \raggedright % Ensures text aligns to the left
-    PONTIFICIA UNIVERSIDAD CATÓLICA DE CHILE\\
-    ESCUELA DE INGENIERÍA
-\end{minipage}
+\coverheader{%
+  PONTIFICIA UNIVERSIDAD CATÓLICA DE CHILE\\
+  ESCUELA DE INGENIERÍA
+}
 
-\vspace{0.2cm}
-\hrule
-\vspace{4cm}
+% Los bloques se separan con glue elástica (\vfill) en vez de medidas fijas: el
+% sobrante de la página se reparte por igual, de modo que el conjunto
+% título/autor queda centrado entre el encabezado y el bloque de la carrera.
+% Ojo: tiene que ser \vfill (orden `fill') y no \stretch/\vfil, porque \newpage
+% agrega su propio \vfil y se llevaría una parte del sobrante.
+\vfill
 
-% Title
-\hspace{3.8cm}
-\begin{minipage}{\textwidth - 7.5cm}
-\begin{center}
-    {\LARGE\textbf{(TITULO TRABAJO)}}
+\begin{coverbody}
+  % El \par va DENTRO del grupo de \LARGE/\large: si se cierra antes, el
+  % párrafo se rompe con el interlineado de 12pt y las líneas se solapan.
+  \begin{center}
+    {\LARGE\textbf{(TITULO TRABAJO)}\par}
 
     \vspace{2cm}
-    {\large\textbf{(NOMBRE COMPLETO)}}
-\end{center}
+    {\large\textbf{(NOMBRE COMPLETO)}\par}
+  \end{center}
+\end{coverbody}
 
-\vspace{2cm}
+\vfill
 
-\noindent Trabajo de Título para optar al título de Ingeniero Civil en ...
+\begin{coverbody}
+  Trabajo de Título para optar al título de Ingeniero Civil en ...
 
-\vspace{1cm}
+  \vspace{1cm}
 
-\noindent Profesor Guía:\\
-\textbf{(NOMBRE PROFE)}
+  Profesor Guía:\\
+  \textbf{(NOMBRE PROFE)}
+\end{coverbody}
 
-\vspace{3cm}
+\vfill
 
-\begin{flushleft}
-    Santiago de Chile, [Mes], [Año]
-\end{flushleft}
-\end{minipage}
+% La guía pide solo el año: "Santiago de Chile, (año)"
+\begin{coverbody}
+  Santiago de Chile, [AÑO]
+\end{coverbody}
+% Deja la fecha un poco por encima del punto donde termina la línea
+% vertical (a 2,5 cm del borde inferior), como en la plantilla oficial.
+\vspace{0.5cm}
 \newpage

--- a/templates/plantilla-trabajo-de-titulo/content/portada-1.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/portada-1.tex
@@ -1,21 +1,14 @@
 
-% La numeración sigue contando desde la portada, pero no se imprime aquí
+% The counter keeps advancing even though the number is not printed here
 \thispagestyle{empty}
 \coverheader{%
   PONTIFICIA UNIVERSIDAD CATÓLICA DE CHILE\\
   ESCUELA DE INGENIERÍA
 }
 
-% Los bloques se separan con glue elástica (\vfill) en vez de medidas fijas: el
-% sobrante de la página se reparte por igual, de modo que el conjunto
-% título/autor queda centrado entre el encabezado y el bloque de la carrera.
-% Ojo: tiene que ser \vfill (orden `fill') y no \stretch/\vfil, porque \newpage
-% agrega su propio \vfil y se llevaría una parte del sobrante.
 \vfill
 
 \begin{coverbody}
-  % El \par va DENTRO del grupo de \LARGE/\large: si se cierra antes, el
-  % párrafo se rompe con el interlineado de 12pt y las líneas se solapan.
   \begin{center}
     {\LARGE\textbf{(TITULO TRABAJO)}\par}
 
@@ -41,7 +34,5 @@
 \begin{coverbody}
   Santiago de Chile, [AÑO]
 \end{coverbody}
-% Deja la fecha un poco por encima del punto donde termina la línea
-% vertical (a 2,5 cm del borde inferior), como en la plantilla oficial.
 \vspace{0.5cm}
 \newpage

--- a/templates/plantilla-trabajo-de-titulo/content/portada-2.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/portada-2.tex
@@ -1,51 +1,53 @@
 
-% The counter keeps advancing even though the number is not printed here
+% La numeración sigue contando desde la portada, pero no se imprime aquí
 \thispagestyle{empty}
-\begin{tikzpicture}[remember picture, overlay]
-\draw[thin] ([xshift=6.85cm, yshift=-2.5cm]current page.north west)|-([xshift=6.85cm, yshift=2.5cm]current page.south west);
-\end{tikzpicture}
-\begin{minipage}{0.2\textwidth}
-    \includegraphics[width=2.3cm]{content/logo.png}
-\end{minipage}%
-\hspace{0cm} % Adjust horizontal spacing
-\begin{minipage}{0.75\textwidth}
-    \raggedright % Ensures text aligns to the left
-    PONTIFICIA UNIVERSIDAD CATÓLICA DE CHILE\\
-    ESCUELA DE INGENIERÍA\\
-    Departamento de [COMPLETAR]
-\end{minipage}
+\coverheader{%
+  PONTIFICIA UNIVERSIDAD CATÓLICA DE CHILE\\
+  ESCUELA DE INGENIERÍA\\
+  Departamento de [COMPLETAR]
+}
 
-\vspace{0.2cm}
-\hrule
-\vspace{4cm}
+% Los bloques se separan con glue elástica (\vfill) en vez de medidas fijas: el
+% sobrante de la página se reparte por igual, de modo que el conjunto
+% título/autor queda centrado entre el encabezado y el bloque de la comisión.
+% Ojo: tiene que ser \vfill (orden `fill') y no \stretch/\vfil, porque \newpage
+% agrega su propio \vfil y se llevaría una parte del sobrante.
+\vfill
 
-% Title
-\hspace{3.8cm}
-\begin{minipage}{\textwidth - 7.5cm}
-    % Title
-\begin{center}
-    {\LARGE\textbf{(TITULO TRABAJO}}
+\begin{coverbody}
+  % El \par va DENTRO del grupo de \LARGE/\large: si se cierra antes, el
+  % párrafo se rompe con el interlineado de 12pt y las líneas se solapan.
+  \begin{center}
+    {\LARGE\textbf{(TITULO TRABAJO)}\par}
 
     \vspace{2cm}
-    {\large\textbf{(NOMBRE COMPLETO)}}
-\end{center}
+    {\large\textbf{(NOMBRE COMPLETO)}\par}
+  \end{center}
+\end{coverbody}
 
-\vspace{1cm}
+\vfill
 
-Trabajo de Título presentado a la Comisión integrada por los profesores:
+\begin{coverbody}
+  Trabajo de Título presentado a la Comisión integrada por los profesores:
 
-\textbf{(PROFESOR 1)}\\
+  \textbf{(PROFESOR GUÍA)}\\
+  \textbf{(PROFESOR REPRESENTANTE DE PREGRADO)}\\
+  \textbf{(PROFESOR INVITADO)}\\
+  \textbf{(PROFESOR INVITADO)}
 
-\textbf{(PROFESOR 2)}\\
+  \vspace{1cm}
 
-\vspace{1cm}
+  Para completar las exigencias del título de
+  Ingeniero Civil en [COMPLETAR]
+\end{coverbody}
 
-Para completar las exigencias del título de
-Ingeniero Civil en [COMPLETAR]
+\vfill
 
-
-
-\vspace{1.7cm}
-Santiago de Chile, [MES], [AÑO]
-\end{minipage}
+% La guía pide solo el año: "Santiago de Chile, (año)"
+\begin{coverbody}
+  Santiago de Chile, [AÑO]
+\end{coverbody}
+% Deja la fecha un poco por encima del punto donde termina la línea
+% vertical (a 2,5 cm del borde inferior), como en la plantilla oficial.
+\vspace{0.5cm}
 \newpage

--- a/templates/plantilla-trabajo-de-titulo/content/portada-2.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/portada-2.tex
@@ -1,5 +1,5 @@
 
-% La numeración sigue contando desde la portada, pero no se imprime aquí
+% The counter keeps advancing even though the number is not printed here
 \thispagestyle{empty}
 \coverheader{%
   PONTIFICIA UNIVERSIDAD CATÓLICA DE CHILE\\
@@ -7,16 +7,9 @@
   Departamento de [COMPLETAR]
 }
 
-% Los bloques se separan con glue elástica (\vfill) en vez de medidas fijas: el
-% sobrante de la página se reparte por igual, de modo que el conjunto
-% título/autor queda centrado entre el encabezado y el bloque de la comisión.
-% Ojo: tiene que ser \vfill (orden `fill') y no \stretch/\vfil, porque \newpage
-% agrega su propio \vfil y se llevaría una parte del sobrante.
 \vfill
 
 \begin{coverbody}
-  % El \par va DENTRO del grupo de \LARGE/\large: si se cierra antes, el
-  % párrafo se rompe con el interlineado de 12pt y las líneas se solapan.
   \begin{center}
     {\LARGE\textbf{(TITULO TRABAJO)}\par}
 
@@ -47,7 +40,5 @@
 \begin{coverbody}
   Santiago de Chile, [AÑO]
 \end{coverbody}
-% Deja la fecha un poco por encima del punto donde termina la línea
-% vertical (a 2,5 cm del borde inferior), como en la plantilla oficial.
 \vspace{0.5cm}
 \newpage

--- a/templates/plantilla-trabajo-de-titulo/content/resumen.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/resumen.tex
@@ -4,7 +4,7 @@
 \begin{center}
     \textbf{RESUMEN}
 \end{center}
-\addcontentsline{toc}{section}{RESUMEN}
+\tocsection{RESUMEN}
 \label{sec:RESUMEN}
 \vspace{1cm}
 

--- a/templates/plantilla-trabajo-de-titulo/content/resumen.tex
+++ b/templates/plantilla-trabajo-de-titulo/content/resumen.tex
@@ -7,6 +7,7 @@
 \tocsection{RESUMEN}
 \label{sec:RESUMEN}
 \vspace{1cm}
+(El resumen no debe contener menos de 100 palabras ni mas de 300 palabras.) (Normal)
 
 
 \newpage

--- a/templates/plantilla-trabajo-de-titulo/main.tex
+++ b/templates/plantilla-trabajo-de-titulo/main.tex
@@ -21,12 +21,36 @@
 \ohead*{\thepage}
 
 
-\renewcommand{\cfttoctitlefont}{\hfill\Large}
-\renewcommand{\cftaftertoctitle}{\hfill\hfill}
-\renewcommand{\cftlottitlefont}{\hfill\Large}
-\renewcommand{\cftafterlottitle}{\hfill\hfill}
-\renewcommand{\cftloftitlefont}{\hfill\Large}
-\renewcommand{\cftafterloftitle}{\hfill\hfill}
+% Titulos de los indices: la plantilla oficial los centra con el formato de un
+% titulo de capitulo (Titulo 1: negrita, 12 pt), no en cuerpo mayor.
+\renewcommand{\cfttoctitlefont}{\hfill\normalsize\bfseries}
+\renewcommand{\cftlottitlefont}{\hfill\normalsize\bfseries}
+\renewcommand{\cftloftitlefont}{\hfill\normalsize\bfseries}
+
+% La guia rotula la columna de paginas con "Pag.", alineado a la derecha. Van
+% dos \hfill: \par cierra el renglon con un \unskip que descarta la ultima
+% glue, de modo que uno se pierde y el otro equilibra el \hfill de
+% \cft...titlefont; con uno solo el titulo terminaria pegado al margen derecho.
+\newcommand{\indexpagelabel}{%
+  \hfill\hfill\par\normalfont\normalsize\vspace{1ex}\hfill Pág.\par}
+\renewcommand{\cftaftertoctitle}{\indexpagelabel}
+\renewcommand{\cftafterlottitle}{\indexpagelabel}
+\renewcommand{\cftafterloftitle}{\indexpagelabel}
+
+% Entradas de los indices como en la guia: "I. TITULO" en el indice general y
+% "Tabla 1.1: ..." / "Figura 1.1: ..." en los de tablas y figuras.
+\renewcommand{\cftsecaftersnum}{.}
+\renewcommand{\cfttabpresnum}{Tabla~}
+\renewcommand{\cfttabaftersnum}{:}
+\renewcommand{\cftfigpresnum}{Figura~}
+\renewcommand{\cftfigaftersnum}{:}
+% Ancho reservado al numero: debe caber la etiqueta mas ancha, que es la de los
+% anexos ("Tabla A.1:" / "Figura A.1:") y dejar aire antes del titulo. Las
+% letras son mas anchas que los digitos, y si el numero desborda la caja empuja
+% la linea (overfull \hbox). En el indice general el numero mas ancho es "III.".
+\cftsetindents{section}{0em}{2.6em}
+\cftsetindents{table}{0em}{6em}
+\cftsetindents{figure}{0em}{6.8em}
 
 
 \begin{document}
@@ -45,16 +69,19 @@
 \input{content/agradecimientos}
 
 %%%%%%%%%%%%%%%%% INDICES %%%%%%%%%%%%%%%%%
+% El indice general no se lista dentro de si mismo: en la guia parte en
+% DEDICATORIA y sigue en INDICE DE TABLAS.
 \renewcommand{\contentsname}{INDICE GENERAL} % Center the title
-\addcontentsline{toc}{section}{INDICE GENERAL}
 \tableofcontents \newpage
 
-%\renewcommand{\listtablename}{INDICE DE TABLAS} % Center the title
-%\addcontentsline{toc}{section}{INDICE DE TABLAS}
-%\listoftables \newpage
+% La guia exige el indice de tablas, igual que el de figuras. El centrado lo
+% pone \cftlottitlefont, no un \begin{center} dentro del nombre.
+\renewcommand{\listtablename}{INDICE DE TABLAS}
+\tocsection{INDICE DE TABLAS}
+\listoftables \newpage
 
-\renewcommand{\listfigurename}{\begin{center}INDICE DE FIGURAS\end{center}} % Center the title
-\addcontentsline{toc}{section}{INDICE DE FIGURAS}
+\renewcommand{\listfigurename}{INDICE DE FIGURAS}
+\tocsection{INDICE DE FIGURAS}
 \listoffigures \newpage
 
 

--- a/templates/plantilla-trabajo-de-titulo/main.tex
+++ b/templates/plantilla-trabajo-de-titulo/main.tex
@@ -21,33 +21,24 @@
 \ohead*{\thepage}
 
 
-% Titulos de los indices: la plantilla oficial los centra con el formato de un
-% titulo de capitulo (Titulo 1: negrita, 12 pt), no en cuerpo mayor.
+% La plantilla oficial centra los títulos de los índices con formato de título de capítulo (negrita, 12 pt)
 \renewcommand{\cfttoctitlefont}{\hfill\normalsize\bfseries}
 \renewcommand{\cftlottitlefont}{\hfill\normalsize\bfseries}
 \renewcommand{\cftloftitlefont}{\hfill\normalsize\bfseries}
 
-% La guia rotula la columna de paginas con "Pag.", alineado a la derecha. Van
-% dos \hfill: \par cierra el renglon con un \unskip que descarta la ultima
-% glue, de modo que uno se pierde y el otro equilibra el \hfill de
-% \cft...titlefont; con uno solo el titulo terminaria pegado al margen derecho.
-\newcommand{\indexpagelabel}{%
-  \hfill\hfill\par\normalfont\normalsize\vspace{1ex}\hfill Pág.\par}
+% La guía rotula la columna de páginas de cada índice con "Pág.", alineado a la derecha
+\newcommand{\indexpagelabel}{\hfill\hfill\par\normalfont\normalsize\vspace{1ex}\hfill Pág.\par}
 \renewcommand{\cftaftertoctitle}{\indexpagelabel}
 \renewcommand{\cftafterlottitle}{\indexpagelabel}
 \renewcommand{\cftafterloftitle}{\indexpagelabel}
 
-% Entradas de los indices como en la guia: "I. TITULO" en el indice general y
-% "Tabla 1.1: ..." / "Figura 1.1: ..." en los de tablas y figuras.
+% La guía lista las entradas como "I. TÍTULO" en el índice general y "Tabla 1.1: ..." / "Figura 1.1: ..." en los demás
 \renewcommand{\cftsecaftersnum}{.}
 \renewcommand{\cfttabpresnum}{Tabla~}
 \renewcommand{\cfttabaftersnum}{:}
 \renewcommand{\cftfigpresnum}{Figura~}
 \renewcommand{\cftfigaftersnum}{:}
-% Ancho reservado al numero: debe caber la etiqueta mas ancha, que es la de los
-% anexos ("Tabla A.1:" / "Figura A.1:") y dejar aire antes del titulo. Las
-% letras son mas anchas que los digitos, y si el numero desborda la caja empuja
-% la linea (overfull \hbox). En el indice general el numero mas ancho es "III.".
+% Ancho reservado al número: debe caber la etiqueta más ancha, la de los anexos ("Tabla A.1:" / "Figura A.1:")
 \cftsetindents{section}{0em}{2.6em}
 \cftsetindents{table}{0em}{6em}
 \cftsetindents{figure}{0em}{6.8em}
@@ -69,13 +60,11 @@
 \input{content/agradecimientos}
 
 %%%%%%%%%%%%%%%%% INDICES %%%%%%%%%%%%%%%%%
-% El indice general no se lista dentro de si mismo: en la guia parte en
-% DEDICATORIA y sigue en ÍNDICE DE TABLAS.
+% En la guía el índice general no se lista a sí mismo: parte en DEDICATORIA y sigue en ÍNDICE DE TABLAS
 \renewcommand{\contentsname}{ÍNDICE GENERAL} % Center the title
 \tableofcontents \newpage
 
-% La guia exige el indice de tablas, igual que el de figuras. El centrado lo
-% pone \cftlottitlefont, no un \begin{center} dentro del nombre.
+% La guía exige el índice de tablas, igual que el de figuras
 \renewcommand{\listtablename}{ÍNDICE DE TABLAS}
 \tocsection{ÍNDICE DE TABLAS}
 \listoftables \newpage

--- a/templates/plantilla-trabajo-de-titulo/main.tex
+++ b/templates/plantilla-trabajo-de-titulo/main.tex
@@ -70,18 +70,18 @@
 
 %%%%%%%%%%%%%%%%% INDICES %%%%%%%%%%%%%%%%%
 % El indice general no se lista dentro de si mismo: en la guia parte en
-% DEDICATORIA y sigue en INDICE DE TABLAS.
-\renewcommand{\contentsname}{INDICE GENERAL} % Center the title
+% DEDICATORIA y sigue en ÍNDICE DE TABLAS.
+\renewcommand{\contentsname}{ÍNDICE GENERAL} % Center the title
 \tableofcontents \newpage
 
 % La guia exige el indice de tablas, igual que el de figuras. El centrado lo
 % pone \cftlottitlefont, no un \begin{center} dentro del nombre.
-\renewcommand{\listtablename}{INDICE DE TABLAS}
-\tocsection{INDICE DE TABLAS}
+\renewcommand{\listtablename}{ÍNDICE DE TABLAS}
+\tocsection{ÍNDICE DE TABLAS}
 \listoftables \newpage
 
-\renewcommand{\listfigurename}{INDICE DE FIGURAS}
-\tocsection{INDICE DE FIGURAS}
+\renewcommand{\listfigurename}{ÍNDICE DE FIGURAS}
+\tocsection{ÍNDICE DE FIGURAS}
 \listoffigures \newpage
 
 

--- a/templates/plantilla-trabajo-de-titulo/main.tex
+++ b/templates/plantilla-trabajo-de-titulo/main.tex
@@ -16,9 +16,6 @@
 \usepackage{tocloft}
 \usepackage{adjustbox}
 
-\usepackage{scrlayer-scrpage} % Modern version of scrpage2
-
-
 % Set page number at the top right corner
 \clearpairofpagestyles
 \ohead*{\thepage}

--- a/templates/plantilla-trabajo-de-titulo/main.tex
+++ b/templates/plantilla-trabajo-de-titulo/main.tex
@@ -101,7 +101,8 @@
 % Hay 2 formas de agregar bibliografia:
 % 1. Agregar una bibliografia en un archivo .bib (Es super automatico)
 %    En el preambulo: \usepackage[style=apa]{biblatex} y \addbibresource{mybib.bib}
-% \printbibliography[title={REFERENCIAS BIBLIOGRÁFICAS}] % Requiere compilar con biber
+%    La guia titula esta seccion "BIBLIOGRAFIA", sin numeral de capitulo.
+% \printbibliography[title={BIBLIOGRAFIA}] % Requiere compilar con biber
 
 % 2. Agregar una bibliografia en un archivo .tex
 % (Es manual, pero comodo para los que no conoce el bibtex)

--- a/templates/plantilla-trabajo-de-titulo/readme.md
+++ b/templates/plantilla-trabajo-de-titulo/readme.md
@@ -7,26 +7,19 @@ Mi trabajo de título, lo hice con este template como base. Fue aceptado por mi 
 
 ## Criterios de formato
 
-La plantilla ya viene configurada con los criterios mínimos de formato que exige
-la Dirección de Pregrado para el Informe de Título, así que no hace falta tocar
-`style.cls` para cumplirlos:
+La plantilla ya viene configurada con los criterios mínimos de formato que exige la Dirección de Pregrado para el Informe de Título, así que no hace falta tocar `style.cls` para cumplirlos:
 
 - Hoja carta, Times New Roman 12 (10 en ilustraciones y tablas).
 - Márgenes de 2,5 cm por los cuatro lados y sangría de primera línea de 1,27 cm.
 - Párrafos justificados y espaciamiento simple.
-- Numeración con números cardinales en la esquina superior derecha, contada
-  **desde la portada** (no se imprime en las dos portadas, pero el contador
-  avanza).
-- Capítulos en números romanos (`I.`, `II.`) y subniveles en árabigos referidos
-  al capítulo (`1.1`, `1.1.1`).
-- Figuras y tablas rotuladas `Figura 1.1` / `Tabla 1.1`, cada una con su índice y
-  con la columna de páginas rotulada `Pág.`.
+- Numeración con números cardinales en la esquina superior derecha, contada **desde la portada** (no se imprime en las dos portadas, pero el contador avanza).
+- Capítulos en números romanos (`I.`, `II.`) y subniveles en árabigos referidos al capítulo (`1.1`, `1.1.1`).
+- Figuras y tablas rotuladas `Figura 1.1` / `Tabla 1.1`, cada una con su índice y con la columna de páginas rotulada `Pág.`.
 - `BIBLIOGRAFIA` sin numeral de capítulo, en formato APA (última edición).
 
 Lo que sí queda de tu lado:
 
-- Extensión: entre 15 y 25 páginas de cuerpo, sin contar tablas, figuras ni
-  anexos.
+- Extensión: entre 15 y 25 páginas de cuerpo, sin contar tablas, figuras ni anexos.
 - Resumen de entre 100 y 300 palabras, y abstract de a lo más una página.
 
 PRs son siempre bienvenidas y agradecidas por la comunidad :rocket:

--- a/templates/plantilla-trabajo-de-titulo/readme.md
+++ b/templates/plantilla-trabajo-de-titulo/readme.md
@@ -5,6 +5,30 @@ En algunas partes el código está medio acoplado, i know, pero no es tan terrib
 
 Mi trabajo de título, lo hice con este template como base. Fue aceptado por mi profe guía y la Dipre. Espero les sirva.
 
+## Criterios de formato
+
+La plantilla ya viene configurada con los criterios mínimos de formato que exige
+la Dirección de Pregrado para el Informe de Título, así que no hace falta tocar
+`style.cls` para cumplirlos:
+
+- Hoja carta, Times New Roman 12 (10 en ilustraciones y tablas).
+- Márgenes de 2,5 cm por los cuatro lados y sangría de primera línea de 1,27 cm.
+- Párrafos justificados y espaciamiento simple.
+- Numeración con números cardinales en la esquina superior derecha, contada
+  **desde la portada** (no se imprime en las dos portadas, pero el contador
+  avanza).
+- Capítulos en números romanos (`I.`, `II.`) y subniveles en árabigos referidos
+  al capítulo (`1.1`, `1.1.1`).
+- Figuras y tablas rotuladas `Figura 1.1` / `Tabla 1.1`, cada una con su índice y
+  con la columna de páginas rotulada `Pág.`.
+- `BIBLIOGRAFIA` sin numeral de capítulo, en formato APA (última edición).
+
+Lo que sí queda de tu lado:
+
+- Extensión: entre 15 y 25 páginas de cuerpo, sin contar tablas, figuras ni
+  anexos.
+- Resumen de entre 100 y 300 palabras, y abstract de a lo más una página.
+
 PRs son siempre bienvenidas y agradecidas por la comunidad :rocket:
 
 

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -181,6 +181,60 @@
     {\normalsize}[\vspace{2ex}]
 
 
+% ====== Portadas ======
+% La plantilla oficial (Word) arma las portadas como una tabla de dos columnas:
+% el logo va en la banda izquierda y el texto SIEMPRE a la derecha de la línea
+% vertical, hasta el margen derecho. Las tres piezas (línea, logo y texto) se
+% derivan de \coverbandwidth, de modo que el texto nunca cruce la línea ni se
+% quede corto antes del margen.
+\newlength{\coverbandwidth}   % ancho de la banda del logo (margen izq. -> línea)
+\setlength{\coverbandwidth}{4.35cm}
+\newlength{\covergutter}      % separación entre la línea vertical y el texto
+\setlength{\covergutter}{0.4cm}
+\newlength{\coverruleoffset}  % del borde izquierdo de la página a la línea vertical
+\newlength{\covertextwidth}   % ancho del bloque de texto (línea -> margen derecho)
+
+% Encabezado de portada. #1: líneas de identificación (universidad, escuela y,
+% si corresponde, departamento).
+\newcommand{\coverheader}[1]{%
+  % 1in+\oddsidemargin es el margen izquierdo que fija geometry (documento a una cara)
+  \setlength{\coverruleoffset}{\dimexpr 1in+\oddsidemargin+\coverbandwidth\relax}%
+  \setlength{\covertextwidth}{\dimexpr\textwidth-\coverbandwidth-\covergutter\relax}%
+  % \noindent va antes del tikzpicture: su caja ya abre el párrafo y, sin esto,
+  % la sangría de 1,27 cm empuja el encabezado fuera del margen derecho.
+  \noindent
+  \begin{tikzpicture}[remember picture, overlay]
+    \draw[thin] ([xshift=\the\coverruleoffset, yshift=-2.5cm]current page.north west)
+    -- ([xshift=\the\coverruleoffset, yshift=2.5cm]current page.south west);
+  \end{tikzpicture}%
+  \begin{minipage}{\coverbandwidth}
+    \raggedleft % el logo se apega a la línea vertical, como en la plantilla
+    \includegraphics[width=2.3cm]{content/logo.png}\hspace*{0.2cm}%
+  \end{minipage}%
+  \hspace{\covergutter}%
+  \begin{minipage}{\covertextwidth}
+    \raggedright
+    #1
+  \end{minipage}
+
+  \vspace{0.2cm}
+  \hrule
+}
+
+% Cuerpo de portada. Alinea el bloque de texto con la banda del encabezado, de
+% modo que arranque a la derecha de la línea vertical y termine en el margen
+% derecho. \coverbandwidth/\covergutter/\covertextwidth los fija \coverheader,
+% que siempre precede a este bloque en la página.
+\newenvironment{coverbody}{%
+  \par\noindent
+  \hspace*{\dimexpr\coverbandwidth+\covergutter\relax}%
+  \begin{minipage}{\covertextwidth}%
+    \setlength{\parindent}{0pt}%
+    \raggedright
+}{%
+  \end{minipage}\par
+}
+
 % Configuracion imagenes
 \newcommand{\fig}[4][\relax]{
   \begin{figure}[H]

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -12,7 +12,11 @@
   \renewcommand{\figurename}{Figura}
   \renewcommand*{\lstlistingname}{Código}
 }
-\RequirePackage[letterpaper, left=2.5cm, top=2.5cm, right=2.5cm, bottom=2.5cm]{geometry} % Configuración de márgenes
+% head=14.5pt reserva para la cabecera el \baselineskip que pide
+% scrlayer-scrpage: sin eso agranda \headheight y encoge \topmargin por su
+% cuenta, y el margen superior deja de ser el de 2,5 cm que exige la guía.
+\RequirePackage[letterpaper, left=2.5cm, top=2.5cm, right=2.5cm, bottom=2.5cm,
+  head=14.5pt]{geometry} % Configuración de márgenes
 \title{Informe trabajo de título}              % Título del documento
 
 % ====== Estilo de Texto ======
@@ -32,6 +36,10 @@
 \RequirePackage{soul}                       % Permite resaltar y decorar texto
 \RequirePackage{bold-extra}                 % Permite utilizar negritas en texto monoespaciado
 \RequirePackage{lscape}                     % Permite orientación horizontal de las páginas
+% scrlayer-scrpage debe cargarse ANTES de titlesec: ambos definen
+% \newpagestyle y, al revés, avisa "it seems that package `titlesec' is used
+% and has already defined `\newpagestyle'".
+\RequirePackage{scrlayer-scrpage}           % Cabeceras y pies de página
 \RequirePackage{titlesec}                   % Permite personalizar los estilos de sección
 \renewcommand\cftsecfont{\normalsize}       % Estilo indice
 \renewcommand\cftsecpagefont{\normalsize}   % Estilo indice

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -74,6 +74,10 @@
 \RequirePackage{ifthen}                     % Soporte para condicionales en el documento
 \RequirePackage[shortlabels]{enumitem}      % Personalización de listas enumeradas y con viñetas
 \RequirePackage[colorlinks=true, linkcolor=black, urlcolor=blue]{hyperref} % Enlaces clicables
+% Ancla + entrada de índice para los títulos sin numerar (\section*): sin
+% \phantomsection el enlace del índice apunta al último destino conocido, que
+% suele ser la página anterior.
+\newcommand{\tocsection}[1]{\phantomsection\addcontentsline{toc}{section}{#1}}
 \RequirePackage{multicol}                   % Soporte para multicolumnas
 \RequirePackage[per-mode = symbol]{siunitx} % Para manejar unidades SI
 \RequirePackage{commath}                    % Mejora la estética en matemáticas
@@ -250,7 +254,7 @@
 
 \newcommand{\startannex}[2]{%
     \section*{Anexo #1: #2} % Print the annex title without numbering
-    \addcontentsline{toc}{section}{Anexo #1. #2} % Add to the table of contents
+    \tocsection{Anexo #1. #2} % Add to the table of contents
     \setcounter{subsection}{0} % Reset subsection counter
     \setcounter{figure}{0} % Reset figure counter for the annex
     \renewcommand{\thesubsection}{#1.\arabic{subsection}} % Set subsection numbering as A.1, A.2, etc.

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -240,8 +240,8 @@
   \begin{figure}[H]
     \centering
     \begin{measuredfigure}
-        \ifx\relax#1\else\label{img:#1}\fi
         \ifx\relax#2\else\caption{#2\vspace{2ex}}\fi
+        \ifx\relax#1\else\label{img:#1}\fi
         \includegraphics[#3]{#4}%
     \end{measuredfigure}
   \end{figure}%
@@ -250,8 +250,8 @@
     \begin{wrapfigure}{#5}{0.25\textwidth} % Margen texto 0.25
         \centering
         \begin{measuredfigure}
-            \ifx\relax#1\else\label{img:#1}\fi
             \ifx\relax#2\else\caption{#2}\fi
+            \ifx\relax#1\else\label{img:#1}\fi
             \includegraphics[#3]{#4} %[scale=0.1]
         \end{measuredfigure}
     \end{wrapfigure}
@@ -261,8 +261,8 @@
     \begin{table}[H]
         \centering
         \begin{measuredfigure}
-            \label{Tab:#1}
             \caption{#2}
+            \label{Tab:#1}
             \includegraphics[#3]{#4}
         \end{measuredfigure}
         \\ \textit{\scriptsize{#5}}

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -79,7 +79,11 @@
 \RequirePackage{wallpaper}                  % Permite utilizar fondos de pantalla en el documento
 \RequirePackage{ifthen}                     % Soporte para condicionales en el documento
 \RequirePackage[shortlabels]{enumitem}      % Personalización de listas enumeradas y con viñetas
-\RequirePackage[colorlinks=true, linkcolor=black, urlcolor=blue]{hyperref} % Enlaces clicables
+% citecolor=black: por omisión hyperref imprime las citas en verde, y la guía no
+% admite texto de color en el cuerpo. Solo las URLs, que APA 7 pide dejar
+% visibles en las referencias, quedan en azul.
+\RequirePackage[colorlinks=true, linkcolor=black, citecolor=black,
+  urlcolor=blue]{hyperref} % Enlaces clicables
 % Ancla + entrada de índice para los títulos sin numerar (\section*): sin
 % \phantomsection el enlace del índice apunta al último destino conocido, que
 % suele ser la página anterior.

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -12,11 +12,8 @@
   \renewcommand{\figurename}{Figura}
   \renewcommand*{\lstlistingname}{Código}
 }
-% head=14.5pt reserva para la cabecera el \baselineskip que pide
-% scrlayer-scrpage: sin eso agranda \headheight y encoge \topmargin por su
-% cuenta, y el margen superior deja de ser el de 2,5 cm que exige la guía.
-\RequirePackage[letterpaper, left=2.5cm, top=2.5cm, right=2.5cm, bottom=2.5cm,
-  head=14.5pt]{geometry} % Configuración de márgenes
+% head=14.5pt reserva la cabecera y mantiene el margen superior de 2,5 cm que exige la guía
+\RequirePackage[letterpaper, left=2.5cm, top=2.5cm, right=2.5cm, bottom=2.5cm, head=14.5pt]{geometry} % Configuración de márgenes
 \title{Informe trabajo de título}              % Título del documento
 
 % ====== Estilo de Texto ======
@@ -34,18 +31,10 @@
 \RequirePackage{mfirstuc}                    % Agrega comandos para capitalizar
 \RequirePackage{dirtytalk}                  % Facilita la adición de comillas
 \RequirePackage{soul}                       % Permite resaltar y decorar texto
-% Espacia las letras de una palabra sin escribir espacios en el texto (la guía
-% titula la portadilla de anexos "A N E X O S"). No se usa \textls de microtype
-% porque XeLaTeX no puede espaciar una fuente Type 1 heredada como ptm: avisa
-% "is a legacy font. Cannot letterspace it" y la deja sin espaciar. soul
-% funciona en cualquier motor.
-\sodef\spacedletters{}{0.4em}{0.5em}{0.5em}
+\sodef\spacedletters{}{0.4em}{0.5em}{0.5em}  % Espacia las letras de una palabra: la guía titula los anexos "A N E X O S"
 \RequirePackage{bold-extra}                 % Permite utilizar negritas en texto monoespaciado
 \RequirePackage{lscape}                     % Permite orientación horizontal de las páginas
-% scrlayer-scrpage debe cargarse ANTES de titlesec: ambos definen
-% \newpagestyle y, al revés, avisa "it seems that package `titlesec' is used
-% and has already defined `\newpagestyle'".
-\RequirePackage{scrlayer-scrpage}           % Cabeceras y pies de página
+\RequirePackage{scrlayer-scrpage}           % Cabeceras y pies de página (va antes de titlesec: ambos definen \newpagestyle)
 \RequirePackage{titlesec}                   % Permite personalizar los estilos de sección
 \renewcommand\cftsecfont{\normalsize}       % Estilo indice
 \renewcommand\cftsecpagefont{\normalsize}   % Estilo indice
@@ -79,15 +68,9 @@
 \RequirePackage{wallpaper}                  % Permite utilizar fondos de pantalla en el documento
 \RequirePackage{ifthen}                     % Soporte para condicionales en el documento
 \RequirePackage[shortlabels]{enumitem}      % Personalización de listas enumeradas y con viñetas
-% citecolor=black: por omisión hyperref imprime las citas en verde, y la guía no
-% admite texto de color en el cuerpo. Solo las URLs, que APA 7 pide dejar
-% visibles en las referencias, quedan en azul.
-\RequirePackage[colorlinks=true, linkcolor=black, citecolor=black,
-  urlcolor=blue]{hyperref} % Enlaces clicables
-% Ancla + entrada de índice para los títulos sin numerar (\section*): sin
-% \phantomsection el enlace del índice apunta al último destino conocido, que
-% suele ser la página anterior.
-\newcommand{\tocsection}[1]{\phantomsection\addcontentsline{toc}{section}{#1}}
+% La guía no admite texto de color en el cuerpo; solo las URLs de las referencias quedan en azul, como pide APA 7
+\RequirePackage[colorlinks=true, linkcolor=black, citecolor=black, urlcolor=blue]{hyperref} % Enlaces clicables
+\newcommand{\tocsection}[1]{\phantomsection\addcontentsline{toc}{section}{#1}} % Agrega al índice un título sin numerar
 \RequirePackage{multicol}                   % Soporte para multicolumnas
 \RequirePackage[per-mode = symbol]{siunitx} % Para manejar unidades SI
 \RequirePackage{commath}                    % Mejora la estética en matemáticas
@@ -158,13 +141,10 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%% OTROS %%%%%%%%%%%%%%%%%%%%%%%
-% La guía numera los capítulos con romanos (I., II.) y los subniveles con
-% árabigos referidos al capítulo (1.1, 1.1.1). Por eso \thesubsection no puede
-% construirse sobre \thesection: heredaría el romano y daría "I.1".
+% La guía numera los capítulos con romanos (I., II.) y los subniveles con árabigos referidos al capítulo (1.1, 1.1.1)
 \renewcommand{\thesection}{\Roman{section}}
 \renewcommand{\thesubsection}{\arabic{section}.\arabic{subsection}}
-\renewcommand{\thesubsubsection}{%
-  \arabic{section}.\arabic{subsection}.\arabic{subsubsection}}
+\renewcommand{\thesubsubsection}{\arabic{section}.\arabic{subsection}.\arabic{subsubsection}}
 
 % Configuramos el "doble espacio" con "2ex"
 \titleformat{\section}[hang]
@@ -186,11 +166,8 @@
 
 
 % ====== Portadas ======
-% La plantilla oficial (Word) arma las portadas como una tabla de dos columnas:
-% el logo va en la banda izquierda y el texto SIEMPRE a la derecha de la línea
-% vertical, hasta el margen derecho. Las tres piezas (línea, logo y texto) se
-% derivan de \coverbandwidth, de modo que el texto nunca cruce la línea ni se
-% quede corto antes del margen.
+% La plantilla oficial (Word) pone el logo en una banda a la izquierda y el texto
+% a la derecha de la línea vertical, hasta el margen derecho.
 \newlength{\coverbandwidth}   % ancho de la banda del logo (margen izq. -> línea)
 \setlength{\coverbandwidth}{4.35cm}
 \newlength{\covergutter}      % separación entre la línea vertical y el texto
@@ -198,21 +175,17 @@
 \newlength{\coverruleoffset}  % del borde izquierdo de la página a la línea vertical
 \newlength{\covertextwidth}   % ancho del bloque de texto (línea -> margen derecho)
 
-% Encabezado de portada. #1: líneas de identificación (universidad, escuela y,
-% si corresponde, departamento).
+% Encabezado de portada. #1: universidad, escuela y, si corresponde, departamento.
 \newcommand{\coverheader}[1]{%
-  % 1in+\oddsidemargin es el margen izquierdo que fija geometry (documento a una cara)
   \setlength{\coverruleoffset}{\dimexpr 1in+\oddsidemargin+\coverbandwidth\relax}%
   \setlength{\covertextwidth}{\dimexpr\textwidth-\coverbandwidth-\covergutter\relax}%
-  % \noindent va antes del tikzpicture: su caja ya abre el párrafo y, sin esto,
-  % la sangría de 1,27 cm empuja el encabezado fuera del margen derecho.
   \noindent
   \begin{tikzpicture}[remember picture, overlay]
     \draw[thin] ([xshift=\the\coverruleoffset, yshift=-2.5cm]current page.north west)
     -- ([xshift=\the\coverruleoffset, yshift=2.5cm]current page.south west);
   \end{tikzpicture}%
   \begin{minipage}{\coverbandwidth}
-    \raggedleft % el logo se apega a la línea vertical, como en la plantilla
+    \raggedleft % el logo se apega a la línea vertical, como en la plantilla oficial
     \includegraphics[width=2.3cm]{content/logo.png}\hspace*{0.2cm}%
   \end{minipage}%
   \hspace{\covergutter}%
@@ -225,10 +198,7 @@
   \hrule
 }
 
-% Cuerpo de portada. Alinea el bloque de texto con la banda del encabezado, de
-% modo que arranque a la derecha de la línea vertical y termine en el margen
-% derecho. \coverbandwidth/\covergutter/\covertextwidth los fija \coverheader,
-% que siempre precede a este bloque en la página.
+% Cuerpo de portada. Usa las medidas que fija \coverheader, que siempre lo precede.
 \newenvironment{coverbody}{%
   \par\noindent
   \hspace*{\dimexpr\coverbandwidth+\covergutter\relax}%
@@ -307,9 +277,7 @@
 % https://tex.stackexchange.com/questions/28333/continuous-v-per-chapter-section-numbering-of-figures-tables-and-other-docume
 \setcounter{figure}{0}
 \setcounter{table}{0}
-% La guía numera figuras y tablas como "Figura 1.1" / "Tabla 1.1": capítulo y
-% correlativo separados por punto. \arabic{section} se mantiene aunque el
-% capítulo se imprima en romanos.
+% La guía rotula figuras y tablas como "Figura 1.1" / "Tabla 1.1": capítulo y correlativo separados por punto
 \renewcommand{\thefigure}{\arabic{section}.\arabic{figure}}
 \renewcommand{\thetable}{\arabic{section}.\arabic{table}}
 %%%%%%%%%%%%%%%%%%%%%%% EXTRA %%%%%%%%%%%%%%%%%%%%%%%

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -34,6 +34,12 @@
 \RequirePackage{mfirstuc}                    % Agrega comandos para capitalizar
 \RequirePackage{dirtytalk}                  % Facilita la adición de comillas
 \RequirePackage{soul}                       % Permite resaltar y decorar texto
+% Espacia las letras de una palabra sin escribir espacios en el texto (la guía
+% titula la portadilla de anexos "A N E X O S"). No se usa \textls de microtype
+% porque XeLaTeX no puede espaciar una fuente Type 1 heredada como ptm: avisa
+% "is a legacy font. Cannot letterspace it" y la deja sin espaciar. soul
+% funciona en cualquier motor.
+\sodef\spacedletters{}{0.4em}{0.5em}{0.5em}
 \RequirePackage{bold-extra}                 % Permite utilizar negritas en texto monoespaciado
 \RequirePackage{lscape}                     % Permite orientación horizontal de las páginas
 % scrlayer-scrpage debe cargarse ANTES de titlesec: ambos definen

--- a/templates/plantilla-trabajo-de-titulo/style.cls
+++ b/templates/plantilla-trabajo-de-titulo/style.cls
@@ -148,6 +148,14 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%% OTROS %%%%%%%%%%%%%%%%%%%%%%%
+% La guía numera los capítulos con romanos (I., II.) y los subniveles con
+% árabigos referidos al capítulo (1.1, 1.1.1). Por eso \thesubsection no puede
+% construirse sobre \thesection: heredaría el romano y daría "I.1".
+\renewcommand{\thesection}{\Roman{section}}
+\renewcommand{\thesubsection}{\arabic{section}.\arabic{subsection}}
+\renewcommand{\thesubsubsection}{%
+  \arabic{section}.\arabic{subsection}.\arabic{subsubsection}}
+
 % Configuramos el "doble espacio" con "2ex"
 \titleformat{\section}[hang]
     {\bfseries}
@@ -235,8 +243,11 @@
 % https://tex.stackexchange.com/questions/28333/continuous-v-per-chapter-section-numbering-of-figures-tables-and-other-docume
 \setcounter{figure}{0}
 \setcounter{table}{0}
-\renewcommand{\thefigure}{\arabic{section}-\arabic{figure}}
-\renewcommand{\thetable}{\arabic{section}-\arabic{table}}
+% La guía numera figuras y tablas como "Figura 1.1" / "Tabla 1.1": capítulo y
+% correlativo separados por punto. \arabic{section} se mantiene aunque el
+% capítulo se imprima en romanos.
+\renewcommand{\thefigure}{\arabic{section}.\arabic{figure}}
+\renewcommand{\thetable}{\arabic{section}.\arabic{table}}
 %%%%%%%%%%%%%%%%%%%%%%% EXTRA %%%%%%%%%%%%%%%%%%%%%%%
 % Desactiva errores de overfull y underfull.
 \hfuzz=\maxdimen
@@ -257,6 +268,8 @@
     \tocsection{Anexo #1. #2} % Add to the table of contents
     \setcounter{subsection}{0} % Reset subsection counter
     \setcounter{figure}{0} % Reset figure counter for the annex
+    \setcounter{table}{0} % Reset table counter for the annex
     \renewcommand{\thesubsection}{#1.\arabic{subsection}} % Set subsection numbering as A.1, A.2, etc.
     \renewcommand{\thefigure}{#1.\arabic{figure}} % Set figure numbering as A.1, A.2, etc..
+    \renewcommand{\thetable}{#1.\arabic{table}} % Set table numbering as A.1, A.2, etc..
 }


### PR DESCRIPTION
# Problema

Siguiendo con lo detallado en la guía de la Dirección de Pregrado (misma fuente que #43), quedaban varias reglas de formato que la plantilla no seguía. Las agrupo por lo que se ve en el PDF.

**Numeración**

> I. TITULO DEL PRIMER CAPITULO *(Heading 1)* 1
> 1.1 Título del Subcapítulo 1 *(Heading 2)* 1
> 1.1.1 Título de la sección 1 *(Heading 3)* 1

- Los capítulos se numeraban en árabigos (`1.`, `2.`), no en romanos.
- Las figuras y tablas salían como `Figura 1-1` / `Tabla 1-1`, con guion en vez de punto.
- `\startannex` renumeraba las figuras de cada anexo como `A.1`, pero no las tablas: seguían contando desde el último capítulo.

**Índices**

> **Indice General**
> Pág.
> DEDICATORIA ii
> …
> \# INDICE DE TABLAS
> Pág.
> Tabla 1.1: Comparación de técnicas basadas en modelos 3

- `\listoftables` estaba comentado, así que no había índice de tablas.
- Ningún índice llevaba el rótulo `Pág.`, y las entradas de tablas y figuras no llevaban la etiqueta `Tabla`/`Figura` ni los dos puntos.
- Los títulos de los índices usaban `\Large` sin negrita; en la plantilla oficial son estilo Título 1 (negrita, 12 pt) como cualquier título de capítulo.
- El índice general se listaba dentro de sí mismo; en la guía parte en DEDICATORIA.
- El índice de figuras centraba su título con un `\begin{center}` dentro de `\listfigurename`, que pelea con `\cftloftitlefont`.

**Bibliografía y anexos**

> BIBLIOGRAFIA 5
> A N E X O S 6

- La bibliografía se titulaba `REFERENCIAS BIBLIOGRÁFICAS` y era una `\section` normal, así que entraba en la secuencia de capítulos y se numeraba.
- La portadilla de anexos decía `ANEXOS`, sin el espaciado entre letras.

**Portadas**

La línea vertical va a 6,85 cm del borde izquierdo, o sea 4,35 cm dentro de la caja de texto, pero el texto se ubicaba con un `\hspace{3.8cm}` fijo y un ancho de `\textwidth-7.5cm`. Resultado: el encabezado se desbordaba 15,89 pt por el margen derecho y el bloque de texto terminaba 2,4 cm antes de ese margen, así que el título no quedaba centrado sobre el área que le corresponde y las líneas cortaban antes de tiempo. La fecha además pedía mes y año, y la guía pide solo el año (`Santiago de Chile, (año)`).

**Cosas que no se ven en el PDF pero avisan al compilar**

- `scrlayer-scrpage` reclamaba dos veces por corrida que `titlesec` ya había definido `\newpagestyle` (se cargaba después de la clase) y que la cabecera era más baja que `\baselineskip`, lo que dejaba un `Overfull \vbox` de 2,5 pt en cada página.
- Los títulos sin numerar (`DEDICATORIA`, `RESUMEN`, `ANEXOS`, cada anexo, …) llegaban al índice con `\addcontentsline` sin `\phantomsection`, así que en `main.toc` apuntaban todos a `Doc-Start` o al último capítulo numerado: clickearlos en el índice llevaba a la página equivocada.
- `\fig`, `\wrapfig` y `\tab` ponían el `\label` antes del `\caption`, y así `\ref` devuelve el número del capítulo en vez del de la figura o tabla.
- `citecolor` quedaba en su valor por omisión, o sea las citas se imprimían en verde.

## Solución

Un commit por tema, todos verificados con `latexmk -xelatex`:

- **Numeración**: `\thesection` pasa a `\Roman{section}`. `\thesubsection` y `\thesubsubsection` no pueden construirse sobre `\thesection` (heredarían el romano y darían `I.1`), así que se arman con `\arabic{section}`. Las figuras y tablas quedan como `1.1`, y `\startannex` también reinicia y renumera las tablas del anexo.
- **Índices**: se activa `\listoftables`, se agrega el rótulo `Pág.` con `\cftafter...title`, y las entradas usan `\cfttabpresnum`/`\cftfigpresnum` para el `Tabla 1.1:` / `Figura 1.1:`. El ancho reservado al número (`\cftsetindents`) tiene que caber la etiqueta más ancha, que es la de los anexos (`Tabla A.1:`), o el número empuja la línea. Los títulos pasan a `\normalsize\bfseries`.
- **Bibliografía**: `\section*{BIBLIOGRAFIA}` más entrada al índice a mano, igual que RESUMEN o ABSTRACT.
- **Anexos**: `\letrasespaciadas` (un `\sodef` de `soul`) espacia las letras sin escribir espacios literales, de modo que la palabra sigue siendo una sola y se puede buscar y copiar. No se usa `\textls` de `microtype` porque bajo XeLaTeX se niega a espaciar una fuente Type 1 heredada como `ptm` (`is a legacy font. Cannot letterspace it`) y la deja sin espaciar. En el índice la entrada va sin espaciar, porque la palabra separada se lee mal en una lista de títulos.
- **Portadas**: las tres piezas (línea, logo y texto) se derivan de un solo largo, `\portadabanda`, así el texto siempre arranca a la derecha de la línea y termina en el margen derecho. `\portadaencabezado` dibuja el encabezado y `\portadacuerpo` alinea cada bloque; los bloques se separan con `\vfill` en vez de medidas fijas, de modo que el sobrante de la página se reparte parejo.
- **Avisos del compilador**: `head=14.5pt` en `geometry` (que deja el margen superior de 2,5 cm bajo control de `geometry` y no de KOMA), `scrlayer-scrpage` cargado en `style.cls` antes de `titlesec`, `\tocsection` como envoltorio de `\phantomsection` + `\addcontentsline`, `\label` después del `\caption` y `citecolor=black`.
- **Ejemplo y readme**: `contenido.tex` gana una tabla de ejemplo para que el nuevo índice no quede en blanco y se vea la numeración, y el readme lista qué criterios de formato ya vienen resueltos y cuáles quedan de tu lado (extensión del cuerpo y del resumen).

Validación: `latexmk -xelatex` antes y después, midiendo sobre el PDF y sobre el `.log`. Para poder comparar cajas mal ajustadas hay que anular temporalmente el `\hfuzz=\maxdimen` que trae la plantilla; con eso, por corrida:

| Criterio | Antes | Después |
|---|---|---|
| Capítulos | `1.`, `2.`, … | `I.`, `II.`, … |
| Figuras y tablas | `Figura 1-1` | `Figura 1.1` |
| Tablas de los anexos | siguen del último capítulo | `A.1`, `B.1`, … |
| Índices | general y de figuras | general, de tablas y de figuras, los tres con `Pág.` |
| Entradas sin numeral con destino propio en el índice | 0 de 9 | 10 de 10 |
| Avisos de `scrlayer-scrpage` | 4 | 0 |
| `Overfull \vbox` | 1 | 0 |
| `Overfull \hbox` (con `\hfuzz` activo) | 2, de 15,89 pt, en las portadas | 0 |
| `Underfull \hbox` (con `\hbadness` activo) | 2 | 0 |

Compila sin errores y sin warnings en la última pasada.

## Puntos de discusión

- Se apunta a `master` porque es donde quedó #43; `develop` está 6 commits atrás y no lo incluye.
- Les puse tilde a los `ÍNDICE`. La plantilla oficial en Word los escribe sin tilde, pero ahí es una errata y no una regla: ese mismo documento acentúa `Pág.` y todo lo demás.
- La tabla de ejemplo en `contenido.tex` es discutible. La agregué porque, sin ninguna tabla, el nuevo índice de tablas queda en blanco y no se ve el formato del rótulo; si prefieren la plantilla vacía, la saco.
